### PR TITLE
update templates to remove deprecation

### DIFF
--- a/templates/aws-iam-deployment.yaml
+++ b/templates/aws-iam-deployment.yaml
@@ -19,7 +19,7 @@
 #
 # This was tested with a kubeadm-installed cluster.
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: iamidentitymappings.iamauthenticator.k8s.aws
@@ -54,7 +54,7 @@ spec:
 
 ---
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: aws-iam-authenticator
   labels:
@@ -86,7 +86,7 @@ metadata:
 
 ---
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: aws-iam-authenticator
   labels:

--- a/templates/aws-iam-deployment.yaml
+++ b/templates/aws-iam-deployment.yaml
@@ -25,7 +25,6 @@ metadata:
   name: iamidentitymappings.iamauthenticator.k8s.aws
 spec:
   group: iamauthenticator.k8s.aws
-  version: v1alpha1
   scope: Cluster
   names:
     plural: iamidentitymappings
@@ -33,25 +32,30 @@ spec:
     kind: IAMIdentityMapping
     categories:
     - all
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          required:
-          - arn
-          - username
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
           properties:
-            arn:
-              type: string
-            username:
-              type: string
-            groups:
-              type: array
-              items:
-                type: string
-
+            spec:
+              type: object
+              required:
+              - arn
+              - username
+              properties:
+                arn:
+                  type: string
+                username:
+                  type: string
+                groups:
+                  type: array
+                  items:
+                    type: string
+      subresources:
+        status: {}
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
the following have been deprecated since [v1.22](https://kubernetes.io/docs/reference/using-api/deprecation-guide/)

* apiextensions.k8s.io/v1beta1
* rbac.authorization.k8s.io/v1beta1


Depends also on:
* https://github.com/charmed-kubernetes/layer-kubernetes-common/pull/42

Fixes [LP:2006978](https://bugs.launchpad.net/charm-aws-iam/+bug/2006978)